### PR TITLE
Fixed trip view for unregistered users

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -360,22 +360,24 @@
           <!-- END Alternative Sidebar Toggle Button -->
 
           <!-- User Dropdown -->
-          <li class="dropdown">
-            <a href="javascript:void(0)" class="dropdown-toggle" data-toggle="dropdown">
-              <%= image_tag current_user.gravatar_url %>
-            </a>
-            <ul class="dropdown-menu dropdown-menu-right">
-              <li class="dropdown-header">
-                <strong><%=current_user.email%></strong>
-              </li>
-              <li>
-                <a href="<%=sign_out_path%>" id="sign_out_link">
-                  <i class="fa fa-power-off fa-fw pull-right"></i>
-                  Log out
+          <% if current_user %>
+              <li class="dropdown">
+                <a href="javascript:void(0)" class="dropdown-toggle" data-toggle="dropdown">
+                  <%= image_tag current_user.gravatar_url %>
                 </a>
+                <ul class="dropdown-menu dropdown-menu-right">
+                  <li class="dropdown-header">
+                    <strong><%=current_user.email%></strong>
+                  </li>
+                  <li>
+                    <a href="<%=sign_out_path%>" id="sign_out_link">
+                      <i class="fa fa-power-off fa-fw pull-right"></i>
+                      Log out
+                    </a>
+                  </li>
+                </ul>
               </li>
-            </ul>
-          </li>
+              <% end %>
           <!-- END User Dropdown -->
         </ul>
         <!-- END Right Header Navigation -->


### PR DESCRIPTION
Trying to view trips as unregistered users created an error page due to attempting to render the dropdown button. Fixed error by not showing the button if no user is logged in.